### PR TITLE
fix: cannot open issue list again when open edit buffer from list buffer.

### DIFF
--- a/autoload/gh.vim
+++ b/autoload/gh.vim
@@ -137,7 +137,7 @@ endfunction
 
 function! s:issue_search() abort
   let filters = getline(".")
-  q
+  bw!
   call win_gotoid(s:old_winid)
 
   " if doesn't changed filters, do nothing
@@ -146,7 +146,7 @@ function! s:issue_search() abort
   endif
 
   let b:gh_action_ctx.args.filters = filters
-  call denops#notify("gh", "doAction", [])
+  call denops#notify("gh", "doAction", ["issues:search"])
 endfunction
 
 augroup gh-issue-search
@@ -197,8 +197,6 @@ function! s:issue_labels() abort
 endfunction
 
 function! gh#_action(type) abort
-  let b:gh_action_ctx.schema.actionType = a:type
-
   if a:type ==# "issues:edit"
     call s:issue_edit()
   elseif a:type ==# "issues:yank"
@@ -210,7 +208,7 @@ function! gh#_action(type) abort
   elseif a:type ==# "issues:labels"
     call s:issue_labels()
   else
-    call denops#notify("gh", "doAction", [])
+    call denops#notify("gh", "doAction", [a:type])
   endif
 endfunction
 

--- a/denops/gh/main.ts
+++ b/denops/gh/main.ts
@@ -5,6 +5,7 @@ import { buildSchema, initializeBuffer } from "./buffer.ts";
 import {
   ActionContext,
   actionStore,
+  ActionType,
   getActionCtx,
   setActionCtx,
 } from "./action.ts";
@@ -49,19 +50,19 @@ export async function main(denops: Denops): Promise<void> {
         await denops.dispatch(
           denops.name,
           "doAction",
+          ctx.schema.actionType,
         );
       } catch (e) {
         console.error(e.message);
       }
     },
 
-    async doAction(): Promise<void> {
+    async doAction(actionType: unknown): Promise<void> {
       try {
         const ctx = await getActionCtx(denops);
-        const schema = ctx.schema;
-        const action = actionStore.get(schema.actionType);
+        const action = actionStore.get(actionType as ActionType);
         if (!action) {
-          throw new Error(`not found action: ${schema.actionType}`);
+          throw new Error(`not found action: ${actionType}`);
         }
         await action(denops, ctx);
       } catch (err) {


### PR DESCRIPTION
CAUSE:
  `schema.ActionType` is used by detect what action to execute.
  But if open edit buffer from list buffer, list buffer's `schema.ActionType` will be overwrited to `issues:edit`,
  so that is cause of cannot open issue list again.

HOW TO FIX:
	In some usecase, action type is different from current buffer's action type.
	For example: issue updating
	So, we have to make possibly to specify action type when call `gh#_action`.
