### PR TITLE
fix: highlight was disappeared when colorscheme changed

### DIFF
--- a/plugin/gh.vim
+++ b/plugin/gh.vim
@@ -7,5 +7,9 @@ if exists('loaded_gh')
 endif
 let g:loaded_gh = 1
 
+augroup gh-define-highlight
+  autocmd ColorScheme * call gh#_define_highlight()
+augroup END
+
 call gh#_define_highlight()
 call gh#_define_signs()


### PR DESCRIPTION
Currently, highlight of gh will disappear when colorscheme changed.
This PR redefines it at changing colorscheme.

Given name to augroup without asking, is it OK? Will change if it problem.