### PR TITLE
Fix: Migrating from Skypack to esm.sh

### DIFF
--- a/denops/gh/deps.ts
+++ b/denops/gh/deps.ts
@@ -15,4 +15,4 @@ export * as fs from "https://deno.land/std@0.119.0/fs/mod.ts";
 export { open } from "https://deno.land/x/open@v0.0.2/index.ts";
 export * as safe_string from "https://deno.land/x/safe_string_literal@v1.0.4/index.js";
 export { delay } from "https://deno.land/std@0.141.0/async/mod.ts";
-export { Octokit } from "https://cdn.skypack.dev/octokit?dts";
+export { Octokit } from "https://esm.sh/octokit?dts";


### PR DESCRIPTION
Thanks for the useful plugin.

## Issue

I get an error when installing for the first time:
```
[Package Error] "@octokit/core@v5.0.0" could not be built.
```

It seems to be due to the use of Skypack. This pr switches to esm.sh from Skypack.

```
We do't publish to skypack, skypack is pulling from the npm registry. Skypack is no longer maintained, please try esm.sh
```

_Originally posted by @gr2m in https://github.com/octokit/octokit.js/issues/2496#issuecomment-1633602260_
